### PR TITLE
Add extractROSInterfaces gradle task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@
 **/gradlew.bat
 **/generatedTestSuites/*TestSuite.java
 **/rebel.xml
+
+# Extracted ihmc_interfaces from gradle task
+ihmc_interfaces

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -239,6 +239,32 @@ app.entrypoint(
    simulationJVMOptions
 )
 
+tasks.register<Copy>("extractROSInterfaces") {
+   from(configurations.runtimeClasspath.map { config ->
+      config.map {
+         if (it.isFile && it.name.equals("ihmc-interfaces-$ihmcOpenRoboticsSoftwareVersion.jar")) {
+            zipTree(it)
+         } else {
+            null
+         }
+      }
+   })
+   duplicatesStrategy = DuplicatesStrategy.INCLUDE
+   include("ihmc_interfaces/**")
+   include("ros1/**")
+   into(project.projectDir.resolve("ihmc_interfaces"))
+
+   doLast {
+      val ihmc_interfaces_dir = file(project.projectDir.resolve("ihmc_interfaces/ihmc_interfaces"))
+      if (ihmc_interfaces_dir.isDirectory) {
+         ihmc_interfaces_dir.renameTo(file(ihmc_interfaces_dir.parentFile.resolve("ros2")))
+      }
+   }
+}
+tasks.named("compileJava") {
+   dependsOn("extractROSInterfaces")
+}
+
 tasks.create("buildDebianSimulationPackage") {
    dependsOn("installDist")
 


### PR DESCRIPTION
I added a new gradle task: `extractROSInterfaces`. It runs whenever `compileJava` task runs, so basically on any gradle operation. This will extract the ros1 and ros2 messages into `<repo parent dir>/ihmc_interfaces`. I added `ihmc_interfaces` to the .gitignore so this won't get commited.

The extracted tree looks like this
```
val-repo/ihmc_interfaces/
├── ros1
│   ├── atlas_msgs
│   │   └── msg
│   ├── behavior_msgs
│   │   └── msg
│   ├── controller_msgs
│   │   ├── CMakeLists.txt
│   │   ├── msg
│   │   └── package.xml
│   ├── exoskeleton_msgs
│   │   └── msg
│   ├── ihmc_common_msgs
│   │   └── msg
│   ├── mission_control_msgs
│   │   └── msg
│   ├── perception_msgs
│   │   └── msg
│   ├── quadruped_msgs
│   │   └── msg
│   ├── test_msgs
│   │   └── msg
│   └── toolbox_msgs
│       └── msg
└── ros2
    ├── atlas_msgs
    │   ├── CMakeLists.txt
    │   ├── msg
    │   └── package.xml
    ├── behavior_msgs
    │   ├── CMakeLists.txt
    │   ├── msg
    │   └── package.xml
    ├── controller_msgs
    │   ├── CMakeLists.txt
    │   ├── msg
    │   └── package.xml
    ├── exoskeleton_msgs
    │   ├── CMakeLists.txt
    │   ├── msg
    │   └── package.xml
    ├── ihmc_common_msgs
    │   ├── CMakeLists.txt
    │   ├── msg
    │   └── package.xml
    ├── mission_control_msgs
    │   ├── CMakeLists.txt
    │   ├── msg
    │   └── package.xml
    ├── perception_msgs
    │   ├── CMakeLists.txt
    │   ├── msg
    │   └── package.xml
    ├── quadruped_msgs
    │   ├── CMakeLists.txt
    │   ├── msg
    │   └── package.xml
    ├── test_msgs
    │   ├── CMakeLists.txt
    │   ├── msg
    │   └── package.xml
    └── toolbox_msgs
        ├── CMakeLists.txt
        ├── msg
        └── package.xml


```